### PR TITLE
5: Update README.md to guide through linters installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git config user.email "john.doe@mail.com"
 
 2. Create virtual environment and install dependencies.
 ```bash
-poetry install
+poetry install --with lint
 ```
 
 3. Activate virual environment.


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/9

In a laborius process of merging feature branch into develop during #3, `linter` group of `pyproject.toml` have become an optional one, however, `README.md` managed to escape its' due update.

In the scope of this quickfix we have to update `README.md` to accomodate `pyproject.toml` changes.