### PR TITLE
9: Add linters to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,69 @@
+name: Lint
+run-name: Lint commit "${{ github.sha }}"
+
+on: push
+jobs:
+  mypy:
+    name: Mypy
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build mypy
+        run: docker compose --file envs/ci/lint/docker-compose.yml build mypy
+
+      - name: Run mypy
+        run: docker compose --file envs/ci/lint/docker-compose.yml run mypy
+
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build ruff
+        run: docker compose --file envs/ci/lint/docker-compose.yml build ruff
+
+      - name: Run ruff
+        run: docker compose --file envs/ci/lint/docker-compose.yml run ruff
+
+  flake8:
+    name: Flake8
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build flake8
+        run: docker compose --file envs/ci/lint/docker-compose.yml build flake8
+
+      - name: Run flake8
+        run: docker compose --file envs/ci/lint/docker-compose.yml run flake8
+
+  pylint:
+    name: Pylint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build pylint
+        run: docker compose --file envs/ci/lint/docker-compose.yml build pylint
+
+      - name: Run pylint
+        run: docker compose --file envs/ci/lint/docker-compose.yml run pylint
+
+  poetry-lock-check:
+    name: Poetry lock check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build Poetry lock check
+        run: docker compose --file envs/ci/lint/docker-compose.yml build poetry-lock-check
+
+      - name: Run poetry-lock-check
+        run: docker compose --file envs/ci/lint/docker-compose.yml run poetry-lock-check

--- a/envs/ci/lint/Dockerfile
+++ b/envs/ci/lint/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    # we need 'enchant-2' for pylint's spellchecker
+    && apt-get -y install enchant-2 \
+    && pip install --upgrade pip \
+    && pip install poetry==1.5.1
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=lint
+
+COPY . ./

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -1,0 +1,27 @@
+name: acih-ci-lint
+
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the current file to the project root dir
+      dockerfile: envs/ci/lint/Dockerfile  # path from the project root dir to the Dockerfile
+
+  mypy:
+    <<: *app-build
+    entrypoint: mypy
+
+  ruff:
+    <<: *app-build
+    entrypoint: ruff check src tests
+
+  flake8:
+    <<: *app-build
+    entrypoint: flake8
+
+  pylint:
+    <<: *app-build
+    entrypoint: pylint src tests
+
+  poetry-lock-check:
+    <<: *app-build
+    entrypoint: poetry lock --check


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/11

In order to prevent untested or otherwise incomplete code being merged into `develop` a CI pipeline needs to be put in place. 

We will use GitHub Actions platform, but final solution will be containerized to be portable to other CI platforms.

In the scope of this task:

1. add `Dockerfile` and `docker-compose.yml` into `envs/ci` directory to launch linters on CI
2. add `lint.yml`  workflow into `.github/workflows`

Note: in our workflow file we decided to have two separate commands `docker compose ... build` and `docker compose ... run` in order to make linter logs to no interfere with build logs from compose.