### PR TITLE
14: Check tests with linters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 
 filename =
     ./src/*,
+    ./tests/*,
 
 exclude =
     __pycache__,
@@ -156,6 +157,12 @@ ignore =
     # ======
     # {name} is too complex ({complexity} > {max_complexity})
     C901,
+
+per-file-ignores =
+    # files with tests
+    tests/*test_*:
+        # Missing docstring
+        D,
 
 
 # NEXT WILL BE LISTED SOME OPTIONS USED BY PLUGINS

--- a/.pylintrc
+++ b/.pylintrc
@@ -114,6 +114,7 @@ disable =
     yield-outside-function,
 
 load-plugins =
+    pylint_per_file_ignores,  # This pylint plugin will enable per-file-ignores in your project
     pylint.extensions.bad_builtin,  # It can be used for finding prohibited used builtins, such as map or filter, for which other alternatives exists.
     pylint.extensions.broad_try_clause,  # Maximum number of statements allowed in a try clause.
     pylint.extensions.check_elif,  # Used when an else statement is immediately followed by an if statement and does not contain statements that would be unrelated to it.
@@ -196,3 +197,8 @@ spelling-private-dict-file = whitelist.txt
 # This flag controls whether the implicit-str-concat should generate a warning
 # on implicit string concatenation in sequences defined over several lines.
 check-str-concat-over-line-jumps = yes
+
+
+# [per-file-ignores]
+# see per file ignores for pylint in pyproject.toml file
+# since plugin we use for that can read only .toml

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -13,6 +13,30 @@ select = [
 src = ["src"]
 
 
+[per-file-ignores]
+
+# files with fixtures
+"tests/**/conftest.py" = [
+    "ARG001",  # Unused function argument: {name}
+]
+
+# files with tests
+"tests/*test_*" = [
+    "ANN",  # Absence of function annotations and type comments.
+    "ARG001",  # Unused function argument: {name}
+    "D",  # Missing docstrings.
+    "PLR2004",  # Magic value used in comparison, consider replacing 200 with a constant variable.
+    "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`.
+    "S101",  # Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
+]
+
+# fixtures file
+"tests/conftest.py" = [
+    "ANN",  # Absence of function annotations and type comments.
+    "PT001",  # Use `@pytest.fixture()` over `@pytest.fixture`.
+]
+
+
 [flake8-annotations]
 
 # Whether to suppress ANN401 for dynamically typed *args and **kwargs arguments

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ mypy
 
 2. Ruff.
 ```bash
-ruff check src
+ruff check src tests
 ```
 
 3. Flake8.
@@ -55,7 +55,7 @@ flake8
 
 4. Pylint.
 ```bash
-pylint src
+pylint src tests 
 ```
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,6 +372,17 @@ spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
 
 [[package]]
+name = "pylint-per-file-ignores"
+version = "1.2.1"
+description = "A pylint plugin to ignore error codes per file."
+optional = false
+python-versions = ">=3.8.1,<4.0.0"
+files = [
+    {file = "pylint_per_file_ignores-1.2.1-py3-none-any.whl", hash = "sha256:09a33dd5a6870286dc0575ed047f2ec59fe19a67df054d68694395eb97266e07"},
+    {file = "pylint_per_file_ignores-1.2.1.tar.gz", hash = "sha256:c2875b982c3edce3637372efdc4889867966c515313627bea32b8558b876b4da"},
+]
+
+[[package]]
 name = "pytest"
 version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
@@ -555,4 +566,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "7e328674c3eeed860fcedd9d11399f8287da9abaa195987e1a63ca1cb7e09402"
+content-hash = "095defa24779b0b63225b4004547f555d14da756abe15b3cdd088fe9680d9e73"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ flake8 = "6.0.0"
 mypy = "1.3.0"
 pyenchant = "3.2.2"  # necessary for pylint spell checking
 pylint = "2.17.4"
+pylint-per-file-ignores = "1.2.1"
 ruff = "0.0.272"
 
 
@@ -34,3 +35,9 @@ optional = true
 [tool.poetry.group.test.dependencies]
 pytest = "7.3.2"
 pytest-cov = "4.1.0"
+
+
+[tool.pylint-per-file-ignores]
+"tests/conftest.py" = """ \
+    redefined-outer-name, \
+"""

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from src.placeholder import func
 
 


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/10

During #7 we didn't configure linters to also check tests.

In the scope of this quckfix we need to:
1. update linters configurations to cover tests
2. update `README.md`
3. refresh poetry lock