### PR TITLE
12: Add tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+run-name: Test commit "${{ github.sha }}"
+
+on: push
+jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Build Pytest
+        run: docker compose --file envs/ci/test/docker-compose.yml build pytest
+
+      - name: Run Pytest
+        run: docker compose --file envs/ci/test/docker-compose.yml run pytest

--- a/envs/ci/test/Dockerfile
+++ b/envs/ci/test/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    # we need 'enchant-2' for pylint's spellchecker
+    && apt-get -y install enchant-2 \
+    && pip install --upgrade pip \
+    && pip install poetry==1.5.1
+
+RUN poetry config virtualenvs.create false
+
+COPY poetry.lock pyproject.toml ./
+
+RUN poetry install --with=test
+
+COPY . ./

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -1,0 +1,11 @@
+name: acih-ci-test
+
+services:
+  app-build: &app-build
+    build:
+      context: ../../..  # path from the current file to the project root dir
+      dockerfile: envs/ci/test/Dockerfile  # path from the project root dir to the Dockerfile
+
+  pytest:
+    <<: *app-build
+    entrypoint: pytest --cov=src


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/11

Now that we've created a functioning CI pipeline it is time to add our project's testing tools to it.

In the scope of this task:
1. create a `docker-compose.yml` service for starting `pytest`.
2. create a `.github/workflows/test.yml` workflow for running tests in CI.