### PR TITLE
Add Docker caching to CI (#17)

### DIFF
--- a/.github/actions/docker/update-buildx-cache/action.yml
+++ b/.github/actions/docker/update-buildx-cache/action.yml
@@ -1,0 +1,12 @@
+name: Update buildx cache
+description: Updates buildx cache correctly to prevent GitHub cache grow forever
+
+runs:
+  using: composite
+  steps:
+    - name: Update buildx cache
+      shell: bash
+      run: |
+        set -o allexport; source ${ENV_FILE}; set +o allexport;  # export environment variables from dotenv file
+        rm -rf ${BUILDX_CACHE_SRC}
+        mv ${BUILDX_CACHE_DEST} ${BUILDX_CACHE_SRC}

--- a/.github/actions/docker/use-buildx-cache/action.yml
+++ b/.github/actions/docker/use-buildx-cache/action.yml
@@ -1,0 +1,17 @@
+name: Use buildx cache
+description: Shortcut for several reusable steps which allow to get/put Docker cache from/in GitHub Cache
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: buildx-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          buildx-${{ runner.os }}-${{ github.ref_name }}
+          buildx-${{ runner.os }}-${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,19 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build mypy
         run: docker compose --file envs/ci/lint/docker-compose.yml build mypy
 
       - name: Run mypy
         run: docker compose --file envs/ci/lint/docker-compose.yml run mypy
+      
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache
 
   ruff:
     name: Ruff
@@ -22,12 +30,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build ruff
         run: docker compose --file envs/ci/lint/docker-compose.yml build ruff
 
       - name: Run ruff
         run: docker compose --file envs/ci/lint/docker-compose.yml run ruff
+      
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache
 
   flake8:
     name: Flake8
@@ -35,12 +51,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build flake8
         run: docker compose --file envs/ci/lint/docker-compose.yml build flake8
 
       - name: Run flake8
         run: docker compose --file envs/ci/lint/docker-compose.yml run flake8
+      
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache
 
   pylint:
     name: Pylint
@@ -48,12 +72,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build pylint
         run: docker compose --file envs/ci/lint/docker-compose.yml build pylint
 
       - name: Run pylint
         run: docker compose --file envs/ci/lint/docker-compose.yml run pylint
+      
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache
 
   poetry-lock-check:
     name: Poetry lock check
@@ -61,9 +93,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build Poetry lock check
         run: docker compose --file envs/ci/lint/docker-compose.yml build poetry-lock-check
 
       - name: Run poetry-lock-check
         run: docker compose --file envs/ci/lint/docker-compose.yml run poetry-lock-check
+      
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,16 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
+      - name: Cache Docker layers
+        uses: ./.github/actions/docker/use-buildx-cache
+
       - name: Build Pytest
         run: docker compose --file envs/ci/test/docker-compose.yml build pytest
 
       - name: Run Pytest
         run: docker compose --file envs/ci/test/docker-compose.yml run pytest
+
+      - name: Update buildx cache
+        env:
+          ENV_FILE: envs/ci/lint/.env
+        uses: ./.github/actions/docker/update-buildx-cache

--- a/envs/ci/lint/.env
+++ b/envs/ci/lint/.env
@@ -1,0 +1,2 @@
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     build:
       context: ../../..  # path from the current file to the project root dir
       dockerfile: envs/ci/lint/Dockerfile  # path from the project root dir to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
 
   mypy:
     <<: *app-build

--- a/envs/ci/test/.env
+++ b/envs/ci/test/.env
@@ -1,0 +1,2 @@
+BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
+BUILDX_CACHE_SRC="/tmp/.buildx-cache"

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -5,6 +5,10 @@ services:
     build:
       context: ../../..  # path from the current file to the project root dir
       dockerfile: envs/ci/test/Dockerfile  # path from the project root dir to the Dockerfile
+      cache_from:
+        - type=local,src=${BUILDX_CACHE_SRC}
+      cache_to:
+        - type=local,dest=${BUILDX_CACHE_DEST}
 
   pytest:
     <<: *app-build


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/12

Now that we've added both linters and test to our CI it is time for optimization. At the moment, our CI pipeline builds its' containers from ground up on every push, which is time consuming. In order to save time we are going to add Docker caching to our CI. It will allow us to use cached layers instead of computing all of them (even unchanged ones) every time.

In the scope of this task we need to:

1. write an action that will setup buildx and cache its' cache
2. create dotenv files and write an action that will update buildx cache (workaround for [that](https://docs.docker.com/build/ci/github-actions/cache/#local-cache))
3. update our workflows and docker compose files accordingly
