### PR TITLE
Faster CI pipeline (#19)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,12 +13,21 @@ jobs:
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
+      - name: Cache mypy
+        uses: actions/cache@v3
+        with:
+          path: ~/.mypy_cache
+          key: mypy-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            mypy-${{ runner.os }}-${{ github.ref_name }}
+            mypy-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build mypy
         run: docker compose --file envs/ci/lint/docker-compose.yml build mypy
 
       - name: Run mypy
         run: docker compose --file envs/ci/lint/docker-compose.yml run mypy
-      
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env
@@ -30,16 +39,25 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      
+
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
+
+      - name: Cache ruff
+        uses: actions/cache@v3
+        with:
+          path: ~/.ruff_cache
+          key: ruff-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ruff-${{ runner.os }}-${{ github.ref_name }}
+            ruff-${{ runner.os }}-${{ github.event.repository.default_branch }}
 
       - name: Build ruff
         run: docker compose --file envs/ci/lint/docker-compose.yml build ruff
 
       - name: Run ruff
         run: docker compose --file envs/ci/lint/docker-compose.yml run ruff
-      
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env
@@ -51,7 +69,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      
+
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
@@ -60,7 +78,7 @@ jobs:
 
       - name: Run flake8
         run: docker compose --file envs/ci/lint/docker-compose.yml run flake8
-      
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env
@@ -72,7 +90,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      
+
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
@@ -81,7 +99,7 @@ jobs:
 
       - name: Run pylint
         run: docker compose --file envs/ci/lint/docker-compose.yml run pylint
-      
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env
@@ -93,7 +111,7 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      
+
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
@@ -102,7 +120,7 @@ jobs:
 
       - name: Run poetry-lock-check
         run: docker compose --file envs/ci/lint/docker-compose.yml run poetry-lock-check
-      
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,21 @@ jobs:
       - name: Cache Docker layers
         uses: ./.github/actions/docker/use-buildx-cache
 
+      - name: Cache pytest
+        uses: actions/cache@v3
+        with:
+          path: ~/.pytest_cache
+          key: pytest-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            pytest-${{ runner.os }}-${{ github.ref_name }}
+            pytest-${{ runner.os }}-${{ github.event.repository.default_branch }}
+
       - name: Build Pytest
         run: docker compose --file envs/ci/test/docker-compose.yml build pytest
 
       - name: Run Pytest
         run: docker compose --file envs/ci/test/docker-compose.yml run pytest
-
+        
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/lint/.env

--- a/envs/ci/lint/docker-compose.yml
+++ b/envs/ci/lint/docker-compose.yml
@@ -12,10 +12,14 @@ services:
 
   mypy:
     <<: *app-build
+    volumes:
+      - ~/.mypy_cache:/app/.mypy_cache
     entrypoint: mypy
 
   ruff:
     <<: *app-build
+    volumes:
+    - ~/.ruff_cache:/app/.ruff_cache
     entrypoint: ruff check src tests
 
   flake8:
@@ -24,7 +28,7 @@ services:
 
   pylint:
     <<: *app-build
-    entrypoint: pylint src tests
+    entrypoint: pylint src tests --jobs=0
 
   poetry-lock-check:
     <<: *app-build

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -12,4 +12,6 @@ services:
 
   pytest:
     <<: *app-build
+    volumes:
+      - ~/.pytest_cache:/app/.pytest_cache
     entrypoint: pytest --cov=src


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/12

Several of our CI elements have ways of increasing their perfomance speed. For example:

- pylint has option --jobs which we can use to specify number of parallel processes
- mypy has a cache directory .mypy_cache
- ruff has a cache directory .ruff_cache
- pytest has a cache directory .pytest_cache

So in the scope of this task we are going to:
1. cache these caches on GitHub server via docker volumes and Cache Action
2. add pylint's --jobs=0 option to `lint/docker-compose.yml`