### PR TITLE
Add cleanup script for force pushed branch (#22)

### DIFF
--- a/envs/ci/cleanup/branch_on_forcepush.py
+++ b/envs/ci/cleanup/branch_on_forcepush.py
@@ -1,0 +1,33 @@
+"""Clean-up script for commits that no longer exist.
+
+Delete GitHub Actions workflow runs for commits that no longer exist
+(i.e. commits that are lost after squashing and force pushing).
+"""
+
+import os
+import sys
+
+from github import Auth, Github
+
+
+BRANCH = sys.argv[1]
+
+GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+
+
+def main():
+    g = Github(auth=Auth.Token(GITHUB_ACCESS_TOKEN))
+    repository = g.get_repo("fenya123/acih-backend")
+
+    branch_commit_shas = []
+    for commit in repository.compare(repository.default_branch, BRANCH).commits:
+        branch_commit_shas.append(commit)
+
+    workflow_runs = repository.get_workflow_runs(branch=BRANCH)
+    for run in workflow_runs:
+        if run.head_sha not in branch_commit_shas:
+            run.delete()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/13

Some commits are usually lost after force pushing. Their respective workflow runs, however, remain. They are no longer needed and have to go.

In the scope of this task we need to write a python script that deletes workflow runs for commits that no longer exist after a force push. We are going to use a [Personal access token](https://github.com/settings/tokens) in order to log in to GitHub because authentication through login-password pair doesn't work at the moment.