### PR TITLE
Add cleanup script for removed branch to CI (#25)

### DIFF
--- a/.github/workflows/cleanup-on-delete.yml
+++ b/.github/workflows/cleanup-on-delete.yml
@@ -1,0 +1,28 @@
+name: Cleanup
+run-name: Cleanup for branch "${{ github.event.ref }}"
+
+on: delete
+jobs:
+  on-delete:
+    name: On delete
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r ./envs/ci/cleanup/requirements.txt
+
+      - name: Run script
+        env:
+          DELETED_BRANCH_NAME: ${{ github.event.ref }}
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 ./envs/ci/cleanup/branch_on_delete.py

--- a/envs/ci/cleanup/branch_on_delete.py
+++ b/envs/ci/cleanup/branch_on_delete.py
@@ -4,20 +4,19 @@ Delete GitHub Actions workflow runs of a branch that has been deleted.
 """
 
 import os
-import sys
 
 from github import Auth, Github
 
 
-DELETED_BRANCH = sys.argv[1]
-
+DELETED_BRANCH_NAME = os.environ["DELETED_BRANCH_NAME"]
 GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
 
 
 def main():
     g = Github(auth=Auth.Token(GITHUB_ACCESS_TOKEN))
-    repository = g.get_repo("fenya123/acih-backend")
-    workflow_runs = repository.get_workflow_runs(branch=DELETED_BRANCH)
+    repository = g.get_repo(GITHUB_REPOSITORY)
+    workflow_runs = repository.get_workflow_runs(branch=DELETED_BRANCH_NAME)
     for run in workflow_runs:
         run.delete()
 


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/13

Now that we have our clenaup script it is time to embed it into our CI pipeline.

In the scope of this task we are going to write a `cleanup-on-delete.yml` Workflow that:
- checkouts our source code, setups `python`
- installs the script's dependenices
- runs the script itself.

NOTES:
We will recieve deleted branche's name through `github.event` payload. Authorization token will be recieved from `secrets.GITHUB_TOKEN` and repository's name will come from github context. This particular task's development will partially occur on `develop` branch due to `on: delete` Workflows requirement of existing on default branch.