### PR TITLE
Improve cleanup workflow to remove its' previous runs (#29)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -50,3 +50,27 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 ./envs/ci/cleanup/branch_on_forcepush.py
+
+  previous-runs:
+    name: Previous runs
+    # we don't want to remove failed runs to make their troubleshooting possible
+    if: ${{ needs.on-delete.result != 'failure' && needs.on-push.result != 'failure' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r ./envs/ci/cleanup/requirements.txt
+
+      - name: Run script
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 ./envs/ci/cleanup/previous_runs.py

--- a/envs/ci/cleanup/previous_runs.py
+++ b/envs/ci/cleanup/previous_runs.py
@@ -1,0 +1,32 @@
+"""Clean-up script for cleanup workflow's previous runs/
+
+Delete previous workflow runs of cleanup.yml.
+"""
+
+import os
+from pathlib import Path
+
+from github import Auth, Github
+
+
+GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+GITHUB_CLEANUP_WORKFLOW = "cleanup.yml"
+GITHUB_REPOSITORY = os.environ["GITHUB_REPOSITORY"]
+
+
+ROOT_DIR = Path(__file__).parents[3]
+if not (ROOT_DIR / ".github" / "workflows" / GITHUB_CLEANUP_WORKFLOW).exists():
+    raise FileNotFoundError("Workflow file does not exist!")
+
+
+def main():
+    g = Github(auth=Auth.Token(GITHUB_ACCESS_TOKEN))
+    repository = g.get_repo(GITHUB_REPOSITORY)
+    workflow = repository.get_workflow(GITHUB_CLEANUP_WORKFLOW)
+    workflow_runs = workflow.get_runs()
+    for run in workflow_runs:
+        run.delete()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/13

The only thing our cleanup workflow lacks is self-cleanup. Every time our `cleanup` workflow is triggered it leaves behind a workflow run that accumulate with time. We only need one, so redundant workflow runs need to be eliminated.

In the scope of this task we are going to add a job to our `cleanup` Workflow that deletes previous runs of `cleanup` workflow.