### PR TITLE
Fix test workflow to use correct dotenv file (#33)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
         
       - name: Update buildx cache
         env:
-          ENV_FILE: envs/ci/lint/.env
+          ENV_FILE: envs/ci/test/.env
         uses: ./.github/actions/docker/update-buildx-cache


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/12

During #17 we've created .env files for our CI workflows. However, we use `envs/ci/lint/.env` in both of our wokflows.

In the scope of this quickfix we need to configure our `test.yml` workflow to use `envs/ci/test/.env` environment file.