### PR TITLE
Fix buildx action to create separate caches (#35)

### DIFF
--- a/.github/actions/docker/use-buildx-cache/action.yml
+++ b/.github/actions/docker/use-buildx-cache/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: /tmp/.buildx-cache
-        key: buildx-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        key: buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
         restore-keys: |
-          buildx-${{ runner.os }}-${{ github.ref_name }}
-          buildx-${{ runner.os }}-${{ github.event.repository.default_branch }}
+          buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.ref_name }}
+          buildx-${{ env.CACHE_KEY_PREFIX }}-${{ runner.os }}-${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Cache mypy
@@ -41,6 +43,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Cache ruff
@@ -71,6 +75,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build flake8
@@ -92,6 +98,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build pylint
@@ -113,6 +121,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-lint'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Build Poetry lock check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache Docker layers
+        env:
+          CACHE_KEY_PREFIX: 'envs-ci-test'  # prefix should match directory which contains Dockerfile used for build
         uses: ./.github/actions/docker/use-buildx-cache
 
       - name: Cache pytest


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/12

During #17 we've written a `use-buildx-cache/action.yml` for caching Docker layers. Both our `lint` and `test` workflows use that action. However, our workflows use separate `docker-compose` files and by extension their jobs are being run on containers build from different images. It makes one workflow's cache useless for another.

In the scope of this quickfix we'll make `use-buildx-cache/action.yml` create separate caches for workflows through specifying unique keys. For each workflow a unique part of cache key will point to its respective directory.