### PR TITLE
 Add linter configurations specific for FastAPI and Pydantic (#38)

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,4 +2,6 @@
 
 files = src
 
+plugins = pydantic.mypy
+
 strict = True

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,14 @@
 [MAIN]
 
+# Pydantic library was added here to prevent `no-name-in-module` error from pylint
+# it looks really weird because all imports from pydantic are resolved with no issues
+# so probably pylint reports this error because pydantic has some part of the code written
+# in C language. I don't know actually whether this is a correct way to handle it
+# So you can check the links below to know more about this issue
+# https://pylint.pycqa.org/en/v2.17.4/user_guide/messages/error/no-member.html
+# https://github.com/pydantic/pydantic/issues/1961
+extension-pkg-whitelist=pydantic
+
 disable =
     # options below are disabled because they are already implemented in ruff
     # if you want to disable another error for some reason, please do it in a separate section above
@@ -115,6 +124,7 @@ disable =
 
 load-plugins =
     pylint_per_file_ignores,  # This pylint plugin will enable per-file-ignores in your project
+    pylint_pydantic,  # A Pylint plugin to help Pylint understand the Pydantic.
     pylint.extensions.bad_builtin,  # It can be used for finding prohibited used builtins, such as map or filter, for which other alternatives exists.
     pylint.extensions.broad_try_clause,  # Maximum number of statements allowed in a try clause.
     pylint.extensions.check_elif,  # Used when an else statement is immediately followed by an if statement and does not contain statements that would be unrelated to it.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -15,6 +15,16 @@ src = ["src"]
 
 [per-file-ignores]
 
+# ignore checks that are raised only when using FastAPI routes
+"src/**/routes.py" = [
+    "TCH",  # Move import into a type-checking block
+]
+
+# ignore checks that are raised only when using Pydantic models
+"src/**/schemas.py" = [
+    "TCH",  # Move import into a type-checking block
+]
+
 # files with fixtures
 "tests/**/conftest.py" = [
     "ARG001",  # Unused function argument: {name}
@@ -43,10 +53,23 @@ src = ["src"]
 allow-star-arg-any = true
 
 
+[flake8-bugbear]
+# Allow default arguments like, e.g., `data: List[str] = fastapi.Query(None)`.
+extend-immutable-calls = ["fastapi.Depends"]
+
+
 [flake8-type-checking]
 
 # Exempt certain modules from needing to be moved into type-checking blocks.
 exempt-modules = []
+
+# Exempt classes that list any of the enumerated classes
+# as a base class from needing to be moved into type-checking blocks.
+runtime-evaluated-base-classes = [
+    # classes inherited from classes listed below
+    # can contain type definitions which are used at runtime
+    "pydantic.BaseSettings",
+]
 
 # Enforce TC001, TC002, and TC003 rules even when valid runtime imports are present for the same module.
 strict = true
@@ -66,3 +89,9 @@ order-by-type = false
 
 # Add the specified import line to all files.
 required-imports = ["from __future__ import annotations"]
+
+
+[pep8-naming]
+
+# Indicate that the method should be treated as a class method (in addition to the builtin @classmethod).
+classmethod-decorators = ["pydantic.root_validator", "pydantic.validator"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -813,6 +813,35 @@ files = [
 ]
 
 [[package]]
+name = "pylint-plugin-utils"
+version = "0.8.2"
+description = "Utilities and helpers for writing Pylint plugins"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pylint_plugin_utils-0.8.2-py3-none-any.whl", hash = "sha256:ae11664737aa2effbf26f973a9e0b6779ab7106ec0adc5fe104b0907ca04e507"},
+    {file = "pylint_plugin_utils-0.8.2.tar.gz", hash = "sha256:d3cebf68a38ba3fba23a873809155562571386d4c1b03e5b4c4cc26c3eee93e4"},
+]
+
+[package.dependencies]
+pylint = ">=1.7"
+
+[[package]]
+name = "pylint-pydantic"
+version = "0.1.8"
+description = "A Pylint plugin to help Pylint understand the Pydantic"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pylint_pydantic-0.1.8-py3-none-any.whl", hash = "sha256:4033c67e06885115fa3bb16e3b9ce918ac6439a87e9b4d314158e09bc1067ecb"},
+]
+
+[package.dependencies]
+pydantic = "<2.0"
+pylint = ">2.0,<3.0"
+pylint-plugin-utils = "*"
+
+[[package]]
 name = "pytest"
 version = "7.3.2"
 description = "pytest: simple powerful testing with Python"
@@ -1363,4 +1392,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "be3efe1138b03354a136074156be30bc0919c940cfe0372368e068829e0ab771"
+content-hash = "62c6ccf75064d3685adb82403912dcf636af8e61ab2adc7f929f3a80b59b13f5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ mypy = "1.3.0"
 pyenchant = "3.2.2"  # necessary for pylint spell checking
 pylint = "2.17.4"
 pylint-per-file-ignores = "1.2.1"
+pylint-pydantic = "0.1.8"  # A Pylint plugin to help Pylint understand the Pydantic.
 ruff = "0.0.272"
 
 


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/14

Since we are going to use FastAPI and Pydantic extensively during backend development, we need to prepare our linters for that. Because both of these libraries have some "features" which some linters cannot understand without additional plugins/configurations.

Configurations added in this ticket came from experience of working with FastAPI-Pydantic-linters setup. None of them we need at exact this moment, but they will be required after a while.

So in this ticket we need to add configuration which will "explain" some features of Pydantic and FastAPI to linters we use.