### PR TITLE
Add PostgreSQL as local container (#37)

### DIFF
--- a/envs/local/dev/.env
+++ b/envs/local/dev/.env
@@ -1,0 +1,2 @@
+POSTGRES_PASSWORD="postgresp"
+POSTGRES_USER="postgresu"

--- a/envs/local/dev/docker-compose.yml
+++ b/envs/local/dev/docker-compose.yml
@@ -1,0 +1,14 @@
+name: acih-local-dev
+
+services:
+  postgres:
+    image: postgres:latest
+    ports:
+      - "5432:5432"
+    env_file:
+      - .env  # path to .env file relative to the current file directory
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+volumes:
+  postgres:


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

Next main development tool on the menu is database. In the scope of this task we need to add PostgreSQL to our project as a local container with attached volume.

Acceptance criteria:
1. a local environment directory with `docker-compose.yml` file are  created
2. `docker exec -it acih-local-dev-postgres-1 /bin/bash` launches `bash` inside container
3. `psql -U <username>` launches `Postgres` inside container
4. ```CREATE TABLE entity (id integer);  INSERT INTO entity VALUES (42);  SELECT * FROM entity;``` returns inserted values **both at the first container run AND after a restart**
5. previously created table cleaned via `DROP TABLE entity;`