### PR TITLE
Configure FastAPI to work with database (#45)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from src.entity.routes import router as entity_router
+
 
 app = FastAPI()
+
+app.include_router(entity_router)
 
 
 @app.get("/")

--- a/src/entity/routes.py
+++ b/src/entity/routes.py
@@ -1,0 +1,28 @@
+"""Routes for Entity package."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from src.entity.models import Entity
+from src.entity.schemas import EntitiesSchema, EntitySchema
+from src.shared.database import Db
+
+
+router = APIRouter()
+
+
+@router.post("/entities/{entity_id}")
+def create_entity(entity_id: int, db: Db) -> EntitySchema:
+    """Create a new entity."""
+    new_entity = Entity(id=entity_id)
+    db.add(new_entity)
+    db.commit()
+    return EntitySchema.from_orm(new_entity)
+
+
+@router.get("/entities")
+def get_entity_list(db: Db) -> EntitiesSchema:
+    """Get list of entities."""
+    entities = db.query(Entity).all()
+    return EntitiesSchema(entities=entities)

--- a/src/entity/schemas.py
+++ b/src/entity/schemas.py
@@ -1,0 +1,22 @@
+"""Pydantic schemas for SQLAlchemy models."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class EntitySchema(BaseModel):
+    """Pydantic schema for Entity model."""
+
+    id: int  # noqa: A003
+
+    class Config:
+        """Configuration for Pydantic schema."""
+
+        orm_mode = True
+
+
+class EntitiesSchema(BaseModel):
+    """Pydantic schema for multiple entities."""
+
+    entities: list[EntitySchema]

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,2 +1,9 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
+
+# package
+Pydantic
+
+
+# plural for "schema"
+schemas


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

After adding Alembic (#43) we can now proceed to configuring our framework to work with database.

In the scope of this task we will:

1. create `src.app.entity.schemas.EntitySchema` to serialize our `Entity` model
2. create a `src.app.database.get_db` FastAPI dependency that will allow us to create separate database sessions for each request and close them when the request is finished
3. create a shortcut `Db` that will inject `get_db` dependency into our routes
4. Create two routes: to create an entity and to get list of entities
5. Connect new routes to application via FastAPI's `APIRouter` class