### PR TITLE
Pytest integration (#47)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -60,8 +60,6 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://pu:pp@localhost:5432/postgres
-
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run

--- a/envs/local/test/.env
+++ b/envs/local/test/.env
@@ -1,0 +1,3 @@
+POSTGRES_DB="postgres"
+POSTGRES_PASSWORD="pp"
+POSTGRES_USER="pu"

--- a/envs/local/test/docker-compose.yml
+++ b/envs/local/test/docker-compose.yml
@@ -1,0 +1,14 @@
+name: acih-local-test
+
+services:
+  postgres:
+    image: postgres:latest
+    ports:
+      - "5433:5432"
+    env_file:
+      - .env  # path to .env file relative to the current file directory
+    volumes:
+      - postgres:/var/lib/postgresql/data
+
+volumes:
+  postgres:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -6,10 +6,12 @@ from sqlalchemy import pool
 from alembic import context
 
 from src.shared.database import Base
+from src.shared.database import connection_uri
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
+config.set_main_option("sqlalchemy.url", connection_uri)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/src/shared/database.py
+++ b/src/shared/database.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from typing import Annotated, TYPE_CHECKING
 
 from fastapi import Depends
-from sqlalchemy import create_engine, URL
+from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, scoped_session, Session, sessionmaker
 
 
@@ -13,14 +14,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-connection_uri = URL.create(
-    "postgresql",
-    username="pu",
-    password="pp",  # noqa: S106
-    host="localhost",
-    port=5432,
-    database="postgres",
-)
+connection_uri = os.environ.get("POSTGRES_CONNECTION_URI", "postgresql://pu:pp@localhost:5433/postgres")
 
 # will allow us to connect to PostgreSQL database
 engine = create_engine(connection_uri)
@@ -37,7 +31,7 @@ class Base(DeclarativeBase):  # pylint: disable=too-few-public-methods
 
 # will allow us to create a separate database connection for each request
 # and close it when the request is finished
-def get_db() -> Iterator[scoped_session[Session]]:
+def get_db() -> Iterator[scoped_session[Session]]:  # pragma: no cover
     """Create session for a request then close it when request is done."""
     try:
         yield session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,40 @@ from __future__ import annotations
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from src.app import app
+from src.entity.models import Entity
+from src.shared.database import get_db
 
 
 @pytest.fixture
-def client():
+def db_empty():
+    """Create clean database with built-in cleanup."""
+    engine = create_engine("postgresql://pu:pp@localhost:5433/postgres")
+    connection = engine.connect()
+    transaction = connection.begin()
+    session = scoped_session(sessionmaker(bind=connection))
+    yield session
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture
+def client(db_empty):
     """FastAPI test client."""
+    def override_get_db():
+        yield db_empty
+    app.dependency_overrides[get_db] = override_get_db
     return TestClient(app)
+
+
+@pytest.fixture
+def db_with_one_entity(db_empty):
+    """Create database with one Entity."""
+    session = db_empty
+    new_entity = Entity(id=1)
+    session.add(new_entity)
+    session.commit()
+    return session

--- a/tests/entity/__init__.py
+++ b/tests/entity/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for 'entity' feature."""

--- a/tests/entity/test_entity_feature.py
+++ b/tests/entity/test_entity_feature.py
@@ -1,0 +1,32 @@
+"""Module for testing entity related endpoints."""
+
+from __future__ import annotations
+
+from src.entity.models import Entity
+
+
+def test_create_entity_returns_200_with_correct_response(client):
+    response = client.post("/entities/1")
+
+    assert response.status_code == 200
+    assert response.json() == {"id": 1}
+
+
+def test_create_entity_adds_data_to_db(client, db_empty):
+    session = db_empty
+
+    client.post("/entities/1")
+
+    assert len(session.query(Entity).all()) == 1
+    assert session.query(Entity).first().id == 1
+
+
+def test_get_entity_list_return_200_with_correct_response(client, db_with_one_entity):
+    response = client.get("/entities")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "entities": [
+            {"id": 1},
+        ],
+    }


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

To ensure long term development efficiency we need our application thoroughly tested. After configuring our framework and database to work together (#45) we can now get to testing. We want our tests to run on a clean database and to cleanup after they're done.

In the scope of this task we will:

1. Set up separate environment for testing with its' own container and volume.
2. Write simple tests for our existing routes.
3. Configure our testing setup in a way that every test is going to be isolated and independent. We will achieve that through using `pytest fixtures` in conjunction with `FastAPI's dependency overrides`.

NOTES:
Regarding implementation: we want our tests to 1) run on a clean database and 2) clean after themselves. We could achieve it by passing our session to tests and repeating the process of `Base.metadata.drop_all` and `...create_all`, then `session.add`ing and `session.commit`ing all the data we need for a given test. We could even encapsulate that process using fixtures to avoid repetitive code. That approach however has significant downsides:
1. `drop_all` method has its' caveats (such as static data or related columns interfering with dropping process)
2. recreating the whole database for each test will inevitably cause performance issues down the line.

A better option will be to provide our tests with a new session that will rollback all changes made with each test run. Considering that every test will require database (empty or otherwise), that session will have to be a `pytest fixture`. With this [approach](https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites) we will run database operations during tests inside a transaction that is going to get rolled back at the end of each test, erasing any data created during it. Code after `yield` is considered a "teardown" and will be executed after the test is done. Our main session is injected into rout functions via `FastAPI's dependency`, so for our tests to work we need to [override](https://fastapi.tiangolo.com/advanced/testing-database/) it with our new session. And because our new session is inside a fixture as well as `TestClient` we unite them inside one.