### PR TITLE
Add Postgres to CI (#51)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,13 @@ jobs:
             pytest-${{ runner.os }}-${{ github.ref_name }}
             pytest-${{ runner.os }}-${{ github.event.repository.default_branch }}
 
-      - name: Build Pytest
-        run: docker compose --file envs/ci/test/docker-compose.yml build pytest
+      - name: Build Pytest & services
+        run: docker compose --file envs/ci/test/docker-compose.yml build
 
-      - name: Run Pytest
-        run: docker compose --file envs/ci/test/docker-compose.yml run pytest
-        
+      - name: Run Pytest & services
+        run: |
+          docker compose --file envs/ci/test/docker-compose.yml up --quiet-pull --attach=pytest --exit-code-from=pytest
+
       - name: Update buildx cache
         env:
           ENV_FILE: envs/ci/test/.env

--- a/envs/ci/test/.env
+++ b/envs/ci/test/.env
@@ -1,2 +1,8 @@
 BUILDX_CACHE_DEST="/tmp/.buildx-cache-new"
 BUILDX_CACHE_SRC="/tmp/.buildx-cache"
+
+POSTGRES_DB="postgres"
+POSTGRES_HOST="postgres"
+POSTGRES_PASSWORD="pp"
+POSTGRES_PORT="5432"
+POSTGRES_USER="pu"

--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -10,8 +10,21 @@ services:
       cache_to:
         - type=local,dest=${BUILDX_CACHE_DEST}
 
+  postgres:
+    image: postgres:latest
+    env_file:
+      - .env
+
   pytest:
     <<: *app-build
     volumes:
       - ~/.pytest_cache:/app/.pytest_cache
-    entrypoint: pytest --cov=src
+    depends_on:
+      - postgres
+    environment:
+      - ACIH_ENV=ci/test
+    entrypoint: |
+      bash -c "
+        alembic upgrade head
+        pytest --cov=src
+      "


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

We need our CI to work with application's configuration and new Pytest implementation.
In the scope of this task we need to update our `yml` files as well as CI environemnt.

NOTES:
**Docker compose**
- we haven't added `expose` option to `postgres` service, because this option already defined in postgres' Dockerfile
- we used `bash -c " ... "` in entrypoint because `alembic ... ; pytest ...` didn't work in default shell inside container
- we haven't added `healtcheck` to postgres because it works without it as of now for some reason. Maybe because of the changes in the latest compose of postgres version. If absence of `healthcheck` will cause an issue after some time, we will apply according fix to it.

**Workflow file**
- we used `--attach=pytest` and `--exit-code-from=pytest` to get output logs and exit code from pytest, in order to have this step failed in case of pytest failure
- we used `--quite-pull` in order to get rid of postgres pulling logs, and make pytest logs more clear