### PR TITLE
Reset autoincrement counters (#53)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from src.app import app
 from src.config import config
 from src.entity.models import Entity
 from src.shared.database import get_db
+from tests.utils.database import set_autoincrement_counters
 
 
 @pytest.fixture
@@ -20,6 +21,7 @@ def db_empty():
     connection = engine.connect()
     transaction = connection.begin()
     session = scoped_session(sessionmaker(bind=connection))
+    set_autoincrement_counters(session)
     yield session
     transaction.rollback()
     connection.close()

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for ACIH back-end testing."""

--- a/tests/utils/database.py
+++ b/tests/utils/database.py
@@ -1,0 +1,18 @@
+"""Database utilities for tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import scoped_session, Session
+
+
+def set_autoincrement_counters(session: scoped_session[Session]) -> None:
+    """Restart auto-increment counters on a value of 10000."""
+    sequences = session.execute(text("SELECT sequencename FROM pg_sequences;")).fetchall()
+    for seq in sequences:
+        session.execute(text(f"ALTER SEQUENCE {seq[0]} RESTART WITH 10000;"))


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

When we create fixtures that add data to database (i.e. `db_with_one_entity`) the way we add it doesn't move database's autoincrement counters. That is a problem because when we try to use those kinds of fixtures in tests that add those same entities we get an error. The code inside the test doesn't know that, in example `entity` with id of 1 already exists, and tries to create an `entity` with that id.

For example:

```python
session.add(Entity(id=1))
session.add(Entity(id=2))
session.commit()  # autoincrement counter didn't change and still points to `1`

session.add(Entity())  # autoincrement counter will give us `1` here
session.commit()  # here we will get "duplicate error" since entity with id=1 already exists
```

In the scope of this task we will:

1. Write a function that is going to restart autoincrement counters on a 10000.
2. Add it to our `db_empty` fixture.

So after this task is done this issue is going to be in this way:

```python
session.add(Entity(id=1))
session.add(Entity(id=2))
session.commit()  # autoincrement counter didn't change and still points to `10000`

session.add(Entity())  # autoincrement counter will give us `10000` here
session.commit()  # there is no "duplicate error" here
```