### PR TITLE
Add datetime to migrations' filenames (#59)

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -8,7 +8,7 @@ script_location = migrations
 # Uncomment the line below if you want the files to be prepended with date and time
 # see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
 # for all available tokens
-# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
 
 # sys.path path, will be prepended to sys.path if present.
 # defaults to the current working directory.
@@ -20,7 +20,7 @@ prepend_sys_path = .
 # installed by adding `alembic[tz]` to the pip requirements
 # string value is passed to dateutil.tz.gettz()
 # leave blank for localtime
-# timezone =
+timezone = UTC
 
 # max length of characters to apply to the
 # "slug" field

--- a/migrations/versions/2023_10_10_1055-18d944595504_create_entity_table.py
+++ b/migrations/versions/2023_10_10_1055-18d944595504_create_entity_table.py
@@ -1,8 +1,8 @@
-"""entity migration
+"""create entity table
 
-Revision ID: 635775e36cd9
+Revision ID: 18d944595504
 Revises: 
-Create Date: 2023-09-18 18:35:47.057160
+Create Date: 2023-10-10 10:55:37.968059+00:00
 
 """
 from typing import Sequence, Union
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '635775e36cd9'
+revision: str = '18d944595504'
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,7 @@ files = [
 
 [package.dependencies]
 Mako = "*"
+python-dateutil = {version = "*", optional = true, markers = "extra == \"tz\""}
 SQLAlchemy = ">=1.3.0"
 typing-extensions = ">=4"
 
@@ -1081,6 +1082,20 @@ pytest = ">=7.3.1"
 test = ["coverage (>=7.2.7)", "pytest-mock (>=3.10)"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1191,6 +1206,17 @@ files = [
     {file = "ruff-0.0.272-py3-none-win_amd64.whl", hash = "sha256:a37ec80e238ead2969b746d7d1b6b0d31aa799498e9ba4281ab505b93e1f4b28"},
     {file = "ruff-0.0.272-py3-none-win_arm64.whl", hash = "sha256:06b8ee4eb8711ab119db51028dd9f5384b44728c23586424fd6e241a5b9c4a3b"},
     {file = "ruff-0.0.272.tar.gz", hash = "sha256:273a01dc8c3c4fd4c2af7ea7a67c8d39bb09bce466e640dd170034da75d14cab"},
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 
 [[package]]
@@ -1671,4 +1697,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "a9fcb179745bf722ebfc4f5e4888df633203d4dc7d72df208242cb4ed8b19803"
+content-hash = "cc1cab85901fc5e9180988f93cec5dc35e896cc456d47ab075d22858f87a5dae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ optional = true
 
 
 [tool.poetry.group.app.dependencies]
-alembic = "1.12.0"
+alembic = {extras = ["tz"], version = "1.12.0"}
 fastapi = {version = "0.95.0", extras = ["all"]}
 psycopg2-binary = "2.9.7"
 sqlalchemy = "2.0.20"


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/15

Our database migrations are generated in a way that their filenames don't provide any automatic sorting which makes it tricky for us to manually navigate through our migrations folder.

In the scope of this task we will configure `alembic.ini` in a way that our migrations' filenames will include timestamps in UTC.