### PR TITLE
Cleanup workflow "needs" fix (#61)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -53,6 +53,7 @@ jobs:
 
   previous-runs:
     name: Previous runs
+    needs: [on-delete, on-push]
     # we don't want to remove failed runs to make their troubleshooting possible
     if: ${{ needs.on-delete.result != 'failure' && needs.on-push.result != 'failure' }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/13

God knows how we did that mistake but after improving cleanup workflow to remove its' previous runs (#29) third job of `cleanup.yml` workflow doesn't work correctly. While working on it we didn't declare `needs` clause.

In the scope of this quickfix we need to add `needs` line to our `cleanup.yml` workflow.