### PR TITLE
Ruff imports qucikfix #63

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -10,9 +10,6 @@ select = [
     "ALL",  # enable all rules by default
 ]
 
-# Allow imports relative to these directories.
-src = ["src"]
-
 
 [per-file-ignores]
 


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/9

During adding linters configuration (#3) we've added a ruff option that allows us to import from `src` without explicitly specifying it.

For example:
```toml
# ruff configuration
src = ["src"]
```

```python
from src.minio import CustomMinio  # this is allowed
from minio import CustomMinio  # this is allowed too
from minio import Minio  # but we also have third party `minio` library
                         # which is going to messed up with our first party `minio`
```

We won't ever need that, plus we currently have a package that shares a name with a third-party library (minio) which messes our imports up.

In the scope of this quickfix we need to get rid of that option.