### PR TITLE
Add deploy workflow (#75)

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,11 @@
 name: Cleanup
 run-name: Cleanup for branch "${{ github.ref_name }}"
 
-on: [delete, push]
+on:
+  delete:
+  push:
+    branches:
+      - "*"
 jobs:
   on-delete:
     name: On delete

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy
+run-name: Deploy commit "${{ github.sha }}"
+
+on:
+  push:
+    tags:
+      - "DEPLOYED/QA"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: executing remote ssh commands using key
+      uses: appleboy/ssh-action@v1.0.0
+      with:
+        host: ${{ secrets.HOST }}
+        username: ${{ secrets.USERNAME }}
+        password: ${{ secrets.PASSWORD }}
+        script: |
+          cd ~/acih-backend
+          docker compose -f envs/qa/deploy/docker-compose.yml down
+          git fetch origin +refs/tags/DEPLOYED/QA:refs/tags/DEPLOYED/QA
+          git checkout tags/DEPLOYED/QA
+          docker compose -f envs/qa/deploy/docker-compose.yml up -d

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,10 @@
 name: Lint
 run-name: Lint commit "${{ github.sha }}"
 
-on: push
+on:
+  push:
+    branches:
+      - "*"
 jobs:
   mypy:
     name: Mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,10 @@
 name: Test
 run-name: Test commit "${{ github.sha }}"
 
-on: push
+on:
+  push:
+    branches:
+      - "*"
 jobs:
   pytest:
     name: Pytest

--- a/README.md
+++ b/README.md
@@ -133,3 +133,19 @@ pytest --cov
 ```bash
 coverage html
 ```
+
+
+## Deploy
+
+CD is implemented with GitHub Actions.
+
+In order to determine which version is currently deployed:
+```bash
+git fetch origin +refs/tags/DEPLOYED/QA:refs/tags/DEPLOYED/QA
+```
+
+In order to trigger deployment:
+```bash
+git tag --annotate --force DEPLOYED/QA --message ''
+git push origin DEPLOYED/QA --force
+```


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/17

We want to automate our deployment process. We will be using GitHub Actions for that purpose. We are going to add a `deploy.yml` workflow that will trigger on a certaing Git tag push and execute commands on VPS. In order to access VPS from Actions platform we will be using [Appleboy](https://github.com/appleboy/ssh-action) Action.

As a part of (#73) we already done:

1. Download Docker on VPS
2. Create SSH key on VPS and link it to GitHub account
3. CLone project's repo to VPS

In the scope of this task we will:

4. Add VPS's secrets to repository
5. Add `deploy.yml` workflow, which will
   - be triggered by pushing `DEPLOYED/QA` tag
   - run script on VPS via SSH which will update our app
7. Update README.md