### PR TITLE
Fix anonymous volumes in dockerized app (#77)

### DIFF
--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -5,12 +5,16 @@ services:
     image: minio/minio
     env_file:
       - .env
+    volumes:
+      - minio:/data
     command: ["server", "/data"]
 
   postgres:
     image: postgres:latest
     env_file:
       - .env
+    volumes:
+      - postgres:/var/lib/postgresql/data
 
   app:
     build:


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/17

In the process of writing Dockerfile during #73 we didn't use volumes in `postgres` and `minio` services. That is why our app's image currently creates containers with anonymous volumes.

In the scope of this quickfix we will:

1. Add volumes to `postgres` and `minio` services in `envs/qa/deploy/docker-compose.yml`