### PR TITLE
Fix errors in README (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To run tests you need to do all steps from [First time setup](#first-time-setup)
 
    _(it should work out of the box but you can adjust it in the way want)_
 ```bash
-cp envs/local/dev/example.env envs/local/dev/.env
+cp envs/local/test/example.env envs/local/test/.env
 ```
 
 2. Start database for local testing


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/17

During #71 we made a couple of errors in README by providing wrong environments for `cp` commands.

In the scope of this quckifix we will:

1. Change envs in `cp` commands to correct ones.