### PR TITLE
Swagger for auth/account endpoints (#81)

### DIFF
--- a/src/account/__init__.py
+++ b/src/account/__init__.py
@@ -1,0 +1,1 @@
+"""Account feature package."""

--- a/src/account/routes.py
+++ b/src/account/routes.py
@@ -1,0 +1,21 @@
+"""Routes for account package."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, status
+
+from src.account.schemas import AccountWithProfile, NewAccount
+
+
+router = APIRouter(tags=["account"])
+
+
+@router.post(
+    "/accounts",
+    response_model=AccountWithProfile,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_account(new_account: Annotated[NewAccount, Body()]) -> None:  # noqa: ARG001
+    """Create account endpoint."""

--- a/src/account/schemas.py
+++ b/src/account/schemas.py
@@ -1,0 +1,30 @@
+"""Pydantic schemas for account feature."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from src.profile.schemas import Profile
+
+
+class NewAccount(BaseModel):
+    """Schema for an account to be created."""
+
+    email: str
+    password: str
+    username: str
+
+
+class Account(BaseModel):
+    """Account schema."""
+
+    id: int  # noqa: A003
+
+    email: str
+
+
+class AccountWithProfile(BaseModel):
+    """Schema for Account and Profile."""
+
+    account: Account
+    profile: Profile

--- a/src/app.py
+++ b/src/app.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from src.account.routes import router as account_router
+from src.auth.routes import router as auth_router
 from src.entity.routes import router as entity_router
 from src.minio.routes import router as minio_router
 
 
 app = FastAPI()
 
+app.include_router(account_router)
+app.include_router(auth_router)
 app.include_router(entity_router)
 app.include_router(minio_router)
 

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Auth feature package."""

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -1,0 +1,8 @@
+"""Fastapi dependencies for auth feature."""
+
+from __future__ import annotations
+
+from fastapi.security import HTTPBearer
+
+
+get_token = HTTPBearer()

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -1,0 +1,44 @@
+"""Routes for auth package."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, Path, status
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth.dependencies import get_token
+from src.auth.schemas import Credentials, Session
+
+
+router = APIRouter(tags=["auth"])
+
+
+@router.post(
+    "/sessions",
+    responses={
+        status.HTTP_403_FORBIDDEN: {},
+    },
+    response_model=Session,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_session(credentials: Annotated[Credentials, Body()]) -> None:  # noqa: ARG001
+    """Create session endpoint."""
+
+
+@router.delete(
+    "/accounts/{account_id}/sessions/{session_id}",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {},
+        status.HTTP_403_FORBIDDEN: {},
+        status.HTTP_404_NOT_FOUND: {},
+    },
+    response_model=None,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def remove_session(
+    account_id: Annotated[int, Path()],  # noqa: ARG001
+    session_id: Annotated[int, Path()],  # noqa: ARG001
+    authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+) -> None:
+    """Remove session endpoint."""

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for auth feature."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Credentials(BaseModel):
+    """Credentials schema."""
+
+    email: str
+    password: str
+
+
+class Session(BaseModel):
+    """Session schema."""
+
+    id: UUID  # noqa: A003
+
+    account_id: int
+    token: str

--- a/src/profile/__init__.py
+++ b/src/profile/__init__.py
@@ -1,0 +1,1 @@
+"""Profile feature package."""

--- a/src/profile/schemas.py
+++ b/src/profile/schemas.py
@@ -1,0 +1,17 @@
+"""Pydantic schemas for profile feature."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Profile(BaseModel):
+    """Profile schema."""
+
+    account_id: int
+
+    avatar_id: str | None
+    background_id: str | None
+    description: str | None
+    info: str | None
+    username: str

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,8 +1,14 @@
 # This is a whitelist of allowed words for flake8-spellcheck plugin.
 # IMPORTANT: please keep this list alphabetically sorted by whitelisted words
 
+# authorization / authentication
+auth
+
 # configuration component
 config
+
+# FastAPI python framework
+fastapi
 
 # package
 minio


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/19

The first step in developing our authentication/authorization fucntionality is devising architecture for its endpoints. Before actually writing code for endpoints we need to think through how they will look, how they will work, what data they will get and return etc.

We've come up with following Sign Up-In-Out system:

1. Client enters e-mail, password, username (password confirmation stays on frontend)
2. Server creates `Account` and `Profile` entities (client is then redirected to sign in page)
3. Client enters credentials (password, username)
4. Server validates client credentials, then creates `Session` entity that is linked to a certaien user's `Account`. Session's id is randomly generated. Session's JWT-token is created from provided data, secret key and session id (see detailed payload description below). Token is then returned to client.
5. Upon trying to access any of our app's endpoint client sends their JWT-token with the request. Server validates token and provides or denies access depending on the result.
6. When client signs out, the request once again contains aformentioned token. After validation, server deletes assosiated session along with the token, returning nothing.

_We decided to not use any JWT standard claims like `sub`, `iss` etc. We want token payload to have our custom data for learning purposes. We believe that it will allow us to understand how tokens work and why exactly we need each part of the data in the payload. Once we get familiar with our custom data and its purposes we can replace it with standard JWT claims._

For our auth system JWT's payload data should contain:

- `user_id` - id of the user's Account (to identify request issuer)
- `session_id` - id of the current auth session which token belongs to (to make tokens to be unique for each session even for the same user, and identify current session which user works with)

Our auth approach has a strong side of allowing multiple separate sessions for a single account. That way, a user can sign in and out of our app on multiple browsers/devices independently. There is, however, an issue of tokens having no expiration date. If a supposed hacker gets hold of a JWT token they could access endpoints that require authorization in a guise of a user they've stolen from. And that would require said user to sign out from session that got hacked, otherwise hacker's access will be indefinite.

In the scope of this task we will:
1. Create `account`, `auth` and `profile` directories
2. Write schemas and add endpoints' architecture to said directories
3. Register them with the app

Acceptance criteria:
Upon starting server for local development and accessing `localhost:8000/docs` we see Swagger documentation for `account` and `auth` endpoints. They showcase all necessary data models, HTTP response codes etc.