### PR TITLE
Pin versions for external dependencies (#83)

### DIFF
--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -11,13 +11,13 @@ services:
         - type=local,dest=${BUILDX_CACHE_DEST}
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-12-06T09-09-22Z
     env_file:
       - .env
     command: ["server", "/data"]
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.1-alpine
     env_file:
       - .env
 

--- a/envs/local/dev/docker-compose.yml
+++ b/envs/local/dev/docker-compose.yml
@@ -2,7 +2,7 @@ name: acih-local-dev
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16.1-alpine
     ports:
       - "5432:5432"
     env_file:
@@ -11,7 +11,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-12-06T09-09-22Z
     ports:
     - "9000:9000"
     - "9090:9090"

--- a/envs/local/test/docker-compose.yml
+++ b/envs/local/test/docker-compose.yml
@@ -2,7 +2,7 @@ name: acih-local-test
 
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:16.1-alpine
     ports:
       - "5433:5432"
     env_file:
@@ -11,7 +11,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-12-06T09-09-22Z
     ports:
     - "9001:9000"
     - "9091:9090"

--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -2,7 +2,7 @@ name: acih-qa-deploy
 
 services:
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2023-12-06T09-09-22Z
     env_file:
       - .env
     volumes:
@@ -10,7 +10,7 @@ services:
     command: ["server", "/data"]
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.1-alpine
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/20

We need to pin versions for external dependencies to avoid version conflicts and other complications in the future (i.e. we've been working with postgres version 15 so far, but after version 16 came out volumes that were created with a previous version stopped working).

In the scope of this task we will:

1. Change our external dependenies (docker, minio) versions from latest to a fixed one.