### PR TITLE
Add healthchecks to CI and CD environments (#87)

### DIFF
--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -12,12 +12,24 @@ services:
 
   minio:
     image: minio/minio:RELEASE.2023-12-06T09-09-22Z
+    healthcheck:
+      # see: https://github.com/minio/minio/issues/18373#issuecomment-1790003599
+      test: timeout 5s bash -c ':> /dev/tcp/${MINIO_HOST}/${MINIO_PORT}' || exit 1
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
     env_file:
       - .env
     command: ["server", "/data"]
 
   postgres:
     image: postgres:16.1-alpine
+    healthcheck:
+      # see: https://github.com/peter-evans/docker-compose-healthcheck#waiting-for-postgresql-to-be-healthy
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      retries: 10
     env_file:
       - .env
 

--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -3,6 +3,13 @@ name: acih-qa-deploy
 services:
   minio:
     image: minio/minio:RELEASE.2023-12-06T09-09-22Z
+    healthcheck:
+      # see: https://github.com/minio/minio/issues/18373#issuecomment-1790003599
+      test: timeout 5s bash -c ':> /dev/tcp/${MINIO_HOST}/${MINIO_PORT}' || exit 1
+      interval: 5s
+      retries: 3
+      start_period: 5s
+      timeout: 5s
     env_file:
       - .env
     volumes:
@@ -11,6 +18,11 @@ services:
 
   postgres:
     image: postgres:16.1-alpine
+    healthcheck:
+      # see: https://github.com/peter-evans/docker-compose-healthcheck#waiting-for-postgresql-to-be-healthy
+      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      retries: 10
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
Parent bug: https://github.com/fenya123/bingin/issues/22

While we were adding [PostgreSQL](https://github.com/fenya123/bingin/issues/15) and [MinIO](https://github.com/fenya123/bingin/issues/16)  to our project we forwent writing healthchecks for these services(#51, #69, #73). It didn't cause any problems then, but it does now (presumably because services updated their Docker configurations).

In the scope of this fix we will:
1. Add healthchecks for MinIO and PostgreSQL on our CI
2. Add healthchecks for MinO and PostgreSQL on our CD