### PR TITLE
Add healthcheck dependency to CI and CD (#97)

### DIFF
--- a/envs/ci/test/docker-compose.yml
+++ b/envs/ci/test/docker-compose.yml
@@ -38,8 +38,10 @@ services:
     volumes:
       - ~/.pytest_cache:/app/.pytest_cache
     depends_on:
-      - postgres
-      - minio
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
     environment:
       - ACIH_ENV=ci/test
     entrypoint: |

--- a/envs/qa/deploy/docker-compose.yml
+++ b/envs/qa/deploy/docker-compose.yml
@@ -35,8 +35,10 @@ services:
     ports:
       - 8000:8000
     depends_on:
-      - postgres
-      - minio
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
     environment:
       - ACIH_ENV=qa/deploy
     volumes:


### PR DESCRIPTION
During #87 we've added healtchecks but forgot to create dependency on them.

In the scope of this quickfix we need to add `condition: service-healthy` to our `envs/ci/test/docker-compose.yml` and `envs/qa/deploy/docker-compose.yml`.