### PR TITLE
Add pagintaion (#99)

### DIFF
--- a/src/feed/routes.py
+++ b/src/feed/routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Query, status
 from fastapi.security import HTTPAuthorizationCredentials
 
 from src.auth.dependencies import get_token
@@ -27,6 +27,8 @@ router = APIRouter(tags=["feed"])
 def get_followed_posts_feed(
     account_id: Annotated[int, Path()],  # noqa: ARG001
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get followed posts for an account."""
 
@@ -44,5 +46,7 @@ def get_followed_posts_feed(
 def get_suggested_posts_feed(
     account_id: Annotated[int, Path()],  # noqa: ARG001
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get suggested posts for an account."""

--- a/src/following/routes.py
+++ b/src/following/routes.py
@@ -60,6 +60,8 @@ def get_following_counts(
 def get_followers(
     account_id: Annotated[int, Path()],  # noqa: ARG001
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get a list of an account's followers."""
 
@@ -77,6 +79,8 @@ def get_followers(
 def get_followees(
     account_id: Annotated[int, Path()],  # noqa: ARG001
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get a list of an account's followees."""
 

--- a/src/post/routes.py
+++ b/src/post/routes.py
@@ -62,6 +62,8 @@ def get_post(
 def get_posts(
     account_id: Annotated[int, Path()],  # noqa: ARG001
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get a list of an account's posts."""
 

--- a/src/search/routes.py
+++ b/src/search/routes.py
@@ -26,5 +26,7 @@ router = APIRouter(tags=["search"])
 def search_accounts(
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
     profile_username: Annotated[str, Query()],  # noqa: ARG001
+    limit: Annotated[int, Query()],  # noqa: ARG001
+    offset: Annotated[int, Query()],  # noqa: ARG001
 ) -> None:
     """Get accounts search result endpoint."""


### PR DESCRIPTION
While developing Swagger documentation for our endpoints (#89, #91, #93, #94) so far we've omitted adding pagination where it is needed.

In the scope of this quickfix we need to add pagination to endpoints that need it.