### PR TITLE
Add Swagger for Files endpoints (#101)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ from src.account.routes import router as account_router
 from src.auth.routes import router as auth_router
 from src.entity.routes import router as entity_router
 from src.feed.routes import router as feed_router
+from src.files.routes import router as files_router
 from src.following.routes import router as follower_router
 from src.minio.routes import router as minio_router
 from src.post.routes import router as post_router
@@ -21,6 +22,7 @@ app.include_router(account_router)
 app.include_router(auth_router)
 app.include_router(entity_router)
 app.include_router(feed_router)
+app.include_router(files_router)
 app.include_router(follower_router)
 app.include_router(minio_router)
 app.include_router(post_router)

--- a/src/files/__init__.py
+++ b/src/files/__init__.py
@@ -1,0 +1,1 @@
+"""Files feature package."""

--- a/src/files/enums.py
+++ b/src/files/enums.py
@@ -1,0 +1,21 @@
+"""Enumerations of file package."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class MimeType(Enum):
+    """Mime type enumeration."""
+
+    IMAGE_PNG = "image/png"
+    IMAGE_JPEG = "image/jpeg"
+
+
+class Extension(Enum):
+    """Extension enumeration."""
+
+    JPE = "jpe"
+    JPEG = "jpeg"
+    JPG = "jpg"
+    PNG = "png"

--- a/src/files/routes.py
+++ b/src/files/routes.py
@@ -1,0 +1,48 @@
+"""Routes for files package."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, status, UploadFile
+from fastapi.responses import FileResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+from src.auth.dependencies import get_token
+from src.files.schemas import File
+
+
+router = APIRouter(tags=["files"])
+
+
+@router.post(
+    "/files",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {},
+        status.HTTP_403_FORBIDDEN: {},
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE: {},
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE: {},
+    },
+    response_model=File,
+    status_code=status.HTTP_201_CREATED,
+)
+def upload_file(
+    authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    file: UploadFile,  # noqa: ARG001
+) -> None:
+    """Upload file endpoint."""
+
+
+@router.get(
+    "/files/{file_id}",
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {},
+        status.HTTP_403_FORBIDDEN: {},
+        status.HTTP_404_NOT_FOUND: {},
+    },
+    response_class=FileResponse,
+)
+def download_file(
+    file_id: Annotated[int, Path()],  # noqa: ARG001
+) -> None:
+    """Download file endpoint."""

--- a/src/files/schemas.py
+++ b/src/files/schemas.py
@@ -1,0 +1,21 @@
+"""Pydantic schemas for files feature."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from src.files.enums import Extension, MimeType
+
+
+class File(BaseModel):
+    """Schema for a file's data."""
+
+    id: int  # noqa: A003
+
+    extension: Extension
+    filename: str
+    mime_type: MimeType
+    size: int
+    upload_ts: datetime

--- a/src/post/schemas.py
+++ b/src/post/schemas.py
@@ -28,7 +28,6 @@ class PostContent(BaseModel):
 
     description: str | None
     file_id: str
-    preview_id: str
     title: str | None
 
 


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/28

The first step in developing our files fucntionality is devising architecture for its endpoints. Before actually writing code for endpoints we need to think through how they will look, how they will work, what data they will get and return etc.

In the scope of this task we will:
1. Write basic endpoint architecture for `files` feature (also pydantic schemas)

--- 

Since this task mostly finalizes our view to the way we're going to work with files, we decided to also reflect those changes to the preview generation process - we encapsulated preview generation into `create_post` endpoint. So `create_post` endpoint shouldn't have `preview_id` in its request body.