### PR TITLE
Add functionality for download_file endpoint (#109)

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,6 +1,7 @@
 ignore = [
     "D203",  # ignores D203 (one-blank-line-before-class) since we use D211 (no-blank-line-before-class)
     "D213",  # ignores D213 (multi-line-summary-second-line) since we use D212 (multi-line-summary-first-line)
+    "N818",  # ignores N818 (error-suffix-on-exception-name) since we use other suffixes like "Exception"
     "S101",  # ignores S101 since we don't use python optiomizations with "-O"
 ]
 

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, status
+from fastapi.responses import JSONResponse
 
 from src.account.routes import router as account_router
 from src.auth.routes import router as auth_router
@@ -13,6 +16,11 @@ from src.following.routes import router as follower_router
 from src.post.routes import router as post_router
 from src.profile.routes import router as profile_router
 from src.search.routes import router as search_router
+from src.shared.exceptions import NotFoundException
+
+
+if TYPE_CHECKING:
+    from fastapi import Request
 
 
 app = FastAPI()
@@ -32,3 +40,9 @@ app.include_router(search_router)
 def root() -> dict[str, str]:
     """Return 'Hello World'."""
     return {"message": "Hello World"}
+
+
+@app.exception_handler(NotFoundException)
+def handle_not_found_exception(_: Request, exc: NotFoundException) -> JSONResponse:
+    """Handle NotFoundException."""
+    return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"detail": exc.detail})

--- a/src/files/controllers.py
+++ b/src/files/controllers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fastapi import Response, status
+
 from src.files.models import File as FileModel
 from src.files.schemas import File as FileSchema
 from src.shared.storage import Minio
@@ -27,3 +29,14 @@ def upload_file(
     )
     client.upload_file(file.id, file_data)
     return FileSchema.model_validate(file, from_attributes=True)
+
+
+def download_file(
+    db: Session,
+    file_id: int,
+) -> Response:
+    """Download file."""
+    client = Minio.get_client()
+    file = FileModel.get_file(db, file_id)
+    data = client.download_file(file.id)
+    return Response(status_code=status.HTTP_200_OK, content=data, media_type=file.mime_type.value)

--- a/src/files/routes.py
+++ b/src/files/routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Path, status
-from fastapi.responses import FileResponse
+from fastapi.responses import Response
 from fastapi.security import HTTPAuthorizationCredentials
 
 from src.auth.dependencies import get_token
@@ -45,10 +45,11 @@ def upload_file(
         status.HTTP_403_FORBIDDEN: {},
         status.HTTP_404_NOT_FOUND: {},
     },
-    response_class=FileResponse,
+    response_class=Response,
 )
 def download_file(
-    db: Db,  # noqa: ARG001
-    file_id: Annotated[int, Path()],  # noqa: ARG001
-) -> None:
+    db: Db,
+    file_id: Annotated[int, Path()],
+) -> Response:
     """Download file endpoint."""
+    return controllers.download_file(db=db, file_id=file_id)

--- a/src/shared/exceptions.py
+++ b/src/shared/exceptions.py
@@ -1,0 +1,17 @@
+"""Module for exception utilities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Self
+
+
+class NotFoundException(Exception):
+    """Raised when some entity hasn't been found."""
+
+    def __init__(self: Self, detail: str) -> None:
+        """Initialize object."""
+        self.detail = detail

--- a/src/shared/storage.py
+++ b/src/shared/storage.py
@@ -46,3 +46,14 @@ class Minio(minio.Minio):  # type: ignore[misc]
     def upload_file(self: Self, file_id: int, file_data: FileData) -> None:
         """Upload file to storage."""
         self.put_object("files", str(file_id), file_data.data, file_data.size)
+
+    def download_file(self: Self, file_id: int) -> bytes:
+        """Return object data as HTTP response."""
+        try:  # pylint: disable=too-many-try-statements
+            response = self.get_object("files", str(file_id))
+            file_data: bytes = response.data
+        finally:
+            response.close()
+            response.release_conn()
+
+        return file_data

--- a/tests/files/test_download_file_endpoint.py
+++ b/tests/files/test_download_file_endpoint.py
@@ -1,0 +1,19 @@
+"""Tests for 'download_file' endpoint."""
+
+from __future__ import annotations
+
+
+def test_download_file_returns_200_with_correct_response(client, storage_with_one_object, db_with_one_file):
+    response = client.get("/files/10000")
+
+    assert response.status_code == 200
+    assert response.content == b"Mockbytesobject"
+    assert response.headers["content-type"] == "image/jpeg"
+    assert response.headers["content-length"] == "15"
+
+
+def test_download_file_with_nonexistent_file_returns_404_with_correct_message(client, db_empty, storage_empty):
+    response = client.get("/files/1337")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Requested file not found."}


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/28

Uploading and downloading images to and from our web application is one of it's most fundamental features. 
There are certain notable descisions we had to make:
1. According to our DDD model, files on our platform might measure all the way up to 200 Mb. Considering this, it was decided to implement file download functionality in a way that allows data to travel to and from our storage using as few steps as possible. Meaning, we want to omit opening/reading file data if we can. We want to come as close to operating on a raw bytes stream as our tools allow us.

In the scope of this task we will:

1. Add functionality to `download_file` endpoint