### PR TITLE
Add functionality for remove_session endpoint (#113)

### DIFF
--- a/src/auth/controllers.py
+++ b/src/auth/controllers.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fastapi import HTTPException, status
+
 from src.account.models import Account
+from src.auth.models import Session as SessionModel
 from src.auth.schemas import Session as SessionSchema
 from src.auth.schemas import SessionWithToken, TokenPayload
 
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     from sqlalchemy.orm import Session
 
     from src.auth.schemas import Credentials
@@ -25,3 +30,12 @@ def create_session(credentials: Credentials, db: Session) -> SessionWithToken:
         session=SessionSchema.model_validate(session, from_attributes=True),
         token=payload.token,
     )
+
+
+def remove_session(account_id: int, token: TokenPayload, db: Session, session_id: UUID) -> None:
+    """Remove session."""
+    if token.account_id != account_id or token.session_id != session_id:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "No rights to perform that action")
+
+    session = SessionModel.get(db, session_id)
+    session.remove(db)

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -2,7 +2,39 @@
 
 from __future__ import annotations
 
-from fastapi.security import HTTPBearer
+from typing import Annotated  # noqa: TCH003
+
+from fastapi import Depends, HTTPException, status  # noqa: TCH002
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer  # noqa: TCH002
+from jwt.exceptions import InvalidSignatureError
+
+from src.account.models import Account
+from src.auth.schemas import TokenPayload
+from src.shared.database import Db  # noqa: TCH001
+from src.shared.exceptions import NotFoundException
 
 
-get_token = HTTPBearer()
+bearer = HTTPBearer()
+
+
+def get_token(
+    token: Annotated[HTTPAuthorizationCredentials, Depends(bearer)],
+    db: Db,
+) -> TokenPayload:
+    """Validate authorization token."""
+    try:
+        payload = TokenPayload.from_token(token.credentials)
+    except InvalidSignatureError:
+        # pylint: disable-next=raise-missing-from
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token.")  # noqa: B904,TRY200
+
+    try:
+        account = Account.get(db, account_id=payload.account_id)
+    except NotFoundException:
+        # pylint: disable-next=raise-missing-from
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token.")  # noqa: B904,TRY200
+
+    if not account.has_session(session_id=payload.session_id):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid token.")
+
+    return payload

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, Path, status
-from fastapi.security import HTTPAuthorizationCredentials
 
 from src.auth import controllers
 from src.auth.dependencies import get_token
-from src.auth.schemas import Credentials, SessionWithToken
+from src.auth.schemas import Credentials, SessionWithToken, TokenPayload
 from src.shared.database import Db
 
 
@@ -40,8 +40,10 @@ def create_session(credentials: Annotated[Credentials, Body()], db: Db) -> Sessi
     status_code=status.HTTP_204_NO_CONTENT,
 )
 def remove_session(
-    account_id: Annotated[int, Path()],  # noqa: ARG001
-    session_id: Annotated[int, Path()],  # noqa: ARG001
-    authorization: Annotated[HTTPAuthorizationCredentials, Depends(get_token)],  # noqa: ARG001
+    account_id: Annotated[int, Path()],
+    session_id: Annotated[UUID, Path()],
+    token: Annotated[TokenPayload, Depends(get_token)],
+    db: Db,
 ) -> None:
     """Remove session endpoint."""
+    return controllers.remove_session(account_id, token, db, session_id)

--- a/src/auth/schemas.py
+++ b/src/auth/schemas.py
@@ -40,6 +40,12 @@ class TokenPayload(BaseModel):
     session_id: UUID
     account_id: int
 
+    @classmethod
+    def from_token(cls: type[TokenPayload], token: str) -> TokenPayload:
+        """Decode JWT token into a class instance."""
+        payload_dict = jwt.decode(token, config.SECRET_KEY, algorithms=[Algorithm.HS256.value])
+        return TokenPayload.model_validate(payload_dict)
+
     @property
     def token(self: Self) -> str:
         """Encode data into JWT token."""

--- a/tests/auth/test_remove_session_endpoint.py
+++ b/tests/auth/test_remove_session_endpoint.py
@@ -1,0 +1,66 @@
+"""Module contains tests for 'remove_session' endpoint."""
+
+from __future__ import annotations
+
+
+def test_remove_session_returns_204(client, db_with_one_account_one_session, token_for_testing):
+    headers = {"Authorization": f"Bearer {token_for_testing}"}
+
+    response = client.delete("/accounts/1/sessions/441d78c0-c031-4fa6-9f2a-78200da5c0fe", headers=headers)
+
+    assert response.status_code == 204
+
+
+def test_remove_session_returns_401_with_correct_body_when_token_has_invalid_signature(
+    client, db_with_one_account_one_session, token_with_false_secret_key,
+):
+    headers = {"Authorization": f"Bearer {token_with_false_secret_key}"}
+
+    response = client.delete("/accounts/1/sessions/441d78c0-c031-4fa6-9f2a-78200da5c0fe", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid token."}
+
+
+def test_remove_session_returns_401_with_correct_body_when_account_from_token_does_not_exist(
+    client, db_empty, token_for_testing,
+):
+    headers = {"Authorization": f"Bearer {token_for_testing}"}
+
+    response = client.delete("/accounts/1/sessions/441d78c0-c031-4fa6-9f2a-78200da5c0fe", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid token."}
+
+
+def test_remove_session_returns_401_with_correct_body_when_account_does_not_have_session_specified(
+    client, db_with_one_account_one_other_session, token_for_testing,
+):
+    headers = {"Authorization": f"Bearer {token_for_testing}"}
+
+    response = client.delete("/accounts/1/sessions/441d78c0-c031-4fa6-9f2a-78200da5c0fe", headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Invalid token."}
+
+
+def test_remove_session_returns_403_with_correct_body_when_query_account_does_not_coincide_with_token_account(
+    client, db_with_one_account_one_session, token_for_testing,
+):
+    headers = {"Authorization": f"Bearer {token_for_testing}"}
+
+    response = client.delete("/accounts/2/sessions/441d78c0-c031-4fa6-9f2a-78200da5c0fe", headers=headers)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "No rights to perform that action"}
+
+
+def test_remove_session_returns_403_with_correct_body_when_query_session_does_not_coincide_with_token_session(
+    client, db_with_one_account_one_session, token_for_testing,
+):
+    headers = {"Authorization": f"Bearer {token_for_testing}"}
+
+    response = client.delete("/accounts/1/sessions/6c0b95da-05e9-4bd5-8580-8695315b6785", headers=headers)
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "No rights to perform that action"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,19 @@ def db_with_one_account_one_session(db_with_one_account):
 
 
 @pytest.fixture
+def db_with_one_account_one_other_session(db_with_one_account):
+    """Add a different session to the same account."""
+    session = db_with_one_account
+    test_session = Session(
+        id=UUID("41cd3cfe-6b14-48a1-8117-f8ba3a7a09af"),
+        account_id=1,
+    )
+    session.add(test_session)
+    session.commit()
+    return session
+
+
+@pytest.fixture
 def token_for_testing():
     """JWT token shortcut."""
     payload = {
@@ -95,6 +108,16 @@ def token_for_testing():
         "session_id": "441d78c0-c031-4fa6-9f2a-78200da5c0fe",
     }
     return jwt.encode(payload, config.SECRET_KEY, AuthAlgorithm.HS256.value)
+
+
+@pytest.fixture
+def token_with_false_secret_key():
+    """Invalid signature token."""
+    payload = {
+        "account_id": 1,
+        "session_id": "441d78c0-c031-4fa6-9f2a-78200da5c0fe",
+    }
+    return jwt.encode(payload, "false_secret", AuthAlgorithm.HS256.value)
 
 
 @pytest.fixture


### PR DESCRIPTION
Parent story: https://github.com/fenya123/bingin/issues/19

With this task we continue developing functionality for our authorization endpoints.

In the scope of this task we will:

1. Go through usual development process (updating schemas, developing controller function etc.)
2. Define a relationship between `Account` and `Session` models.
3. Write a dependecy `get_token` that will pass authorization credentials to endpoints across all our application.
4. Encapsulate token decoding in a pydantic schema (OOP)